### PR TITLE
feat: add BalanceApiClient integration with configurable BaseAddress

### DIFF
--- a/ECommerceApp.Api/appsettings.json
+++ b/ECommerceApp.Api/appsettings.json
@@ -23,5 +23,8 @@
         }
       }
     ]
+  },
+  "ExternalServices": {
+    "BalanceApiBaseUrl": "https://balance-management-pi44.onrender.com"
   }
 }

--- a/ECommerceApp.Application/ECommerceApp.Application.csproj
+++ b/ECommerceApp.Application/ECommerceApp.Application.csproj
@@ -7,8 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Mapster" Version="7.4.0" />
+      <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.18" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ECommerceApp.Domain/DTOs/External/OrderDto.cs
+++ b/ECommerceApp.Domain/DTOs/External/OrderDto.cs
@@ -1,0 +1,23 @@
+namespace ECommerceApp.Domain.DTOs.External;
+
+public class PreOrderRequestDto
+{
+    public List<string> ProductIds { get; set; } = new();
+}
+
+public class PreOrderResponseDto
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = string.Empty;
+}
+
+public class CompleteOrderRequestDto
+{
+    public string OrderId { get; set; } = string.Empty;
+}
+
+public class CompleteOrderResponseDto
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/ECommerceApp.Domain/DTOs/External/ProductResponseDto.cs
+++ b/ECommerceApp.Domain/DTOs/External/ProductResponseDto.cs
@@ -1,0 +1,12 @@
+namespace ECommerceApp.Domain.DTOs.External;
+
+public class ProductResponseDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public int Stock { get; set; }
+}

--- a/ECommerceApp.Domain/ECommerceApp.Domain.csproj
+++ b/ECommerceApp.Domain/ECommerceApp.Domain.csproj
@@ -6,4 +6,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <Folder Include="DTOs\" />
+    </ItemGroup>
+
 </Project>

--- a/ECommerceApp.Infrastructure/Configurations/BalanceApiSettings.cs
+++ b/ECommerceApp.Infrastructure/Configurations/BalanceApiSettings.cs
@@ -1,0 +1,6 @@
+namespace ECommerceApp.Infrastructure.Configurations;
+
+public class BalanceApiSettings
+{
+    public string BalanceApiBaseUrl { get; set; } = string.Empty;
+}

--- a/ECommerceApp.Infrastructure/ECommerceApp.Infrastructure.csproj
+++ b/ECommerceApp.Infrastructure/ECommerceApp.Infrastructure.csproj
@@ -16,5 +16,9 @@
       <PackageReference Include="Newtonsoft.json" Version="13.0.3" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\ECommerceApp.Domain\ECommerceApp.Domain.csproj" />
+    </ItemGroup>
+
 
 </Project>

--- a/ECommerceApp.Infrastructure/Interfaces/IBalanceApiClient.cs
+++ b/ECommerceApp.Infrastructure/Interfaces/IBalanceApiClient.cs
@@ -1,0 +1,9 @@
+namespace ECommerceApp.Infrastructure.Interfaces;
+using ECommerceApp.Domain.DTOs.External;
+
+public interface IBalanceApiClient
+{
+    Task<List<ProductResponseDto>> GetProductsAsync();
+    Task<PreOrderResponseDto> PreOrderAsync(PreOrderRequestDto request);
+    Task<CompleteOrderResponseDto> CompleteOrderAsync(CompleteOrderRequestDto request);
+}

--- a/ECommerceApp.Infrastructure/Services/BalanceApiClient.cs
+++ b/ECommerceApp.Infrastructure/Services/BalanceApiClient.cs
@@ -1,0 +1,45 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using ECommerceApp.Domain.DTOs.External;
+using ECommerceApp.Infrastructure.Configurations;
+using ECommerceApp.Infrastructure.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace ECommerceApp.Infrastructure.Services;
+
+public class BalanceApiClient : IBalanceApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public BalanceApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<List<ProductResponseDto>> GetProductsAsync()
+    {
+        var response = await _httpClient.GetAsync("/products");
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<List<ProductResponseDto>>();
+        return result ?? new();
+    }
+
+    public async Task<PreOrderResponseDto> PreOrderAsync(PreOrderRequestDto request)
+    {
+        var response = await _httpClient.PostAsJsonAsync("/preorder", request);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<PreOrderResponseDto>();
+        return result!;
+    }
+
+    public async Task<CompleteOrderResponseDto> CompleteOrderAsync(CompleteOrderRequestDto request)
+    {
+        var response = await _httpClient.PostAsJsonAsync("/complete", request);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<CompleteOrderResponseDto>();
+        return result!;
+    }
+}

--- a/ECommerceApp.Persistence/ECommerceApp.Persistence.csproj
+++ b/ECommerceApp.Persistence/ECommerceApp.Persistence.csproj
@@ -12,4 +12,8 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.18" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\ECommerceApp.Domain\ECommerceApp.Domain.csproj" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR integrates the BalanceApiClient HTTP service into the project. The service's BaseAddress is now configurable via appsettings.json.