### PR TITLE
Add Redis fallback logic and unit test for ProductService GetAllAsync method

### DIFF
--- a/ECommerceApp.Api/Controllers/ProductsController.cs
+++ b/ECommerceApp.Api/Controllers/ProductsController.cs
@@ -1,6 +1,8 @@
 using ECommerceApp.Application.DTOs.Product;
 using ECommerceApp.Application.Interfaces;
 using ECommerceApp.Domain.Entities;
+using ECommerceApp.Infrastructure.Interfaces;
+using Mapster;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ECommerceApp.Api.Controllers;
@@ -19,6 +21,7 @@ public class ProductsController : ControllerBase
         _productService = productService;
     }
 
+    
     /// <summary>
     /// Returns all products.
     /// </summary>

--- a/ECommerceApp.Infrastructure/Interfaces/ICacheService.cs
+++ b/ECommerceApp.Infrastructure/Interfaces/ICacheService.cs
@@ -1,9 +1,25 @@
-using StackExchange.Redis;
-
 namespace ECommerceApp.Infrastructure.Interfaces;
+using StackExchange.Redis;
 
 public interface ICacheService
 {
+    // <summary>
+    /// GetDb
+    /// </summary>
     IDatabase GetDb(int db = 0);
+    
+    // <summary>
+    /// Stores the given value in the cache under the specified key.
+    /// </summary>
+    Task SetAsync<T>(string key, T value);
 
+    /// <summary>
+    /// Retrieves the value stored in the cache under the specified key.
+    /// </summary>
+    Task<T?> GetAsync<T>(string key);
+
+    /// <summary>
+    /// Removes the cached value associated with the specified key.
+    /// </summary>
+    Task RemoveAsync(string key);
 }

--- a/ECommerceApp.Infrastructure/Services/RedisCacheService.cs
+++ b/ECommerceApp.Infrastructure/Services/RedisCacheService.cs
@@ -1,20 +1,53 @@
-using ECommerceApp.Infrastructure.Configurations;
-using StackExchange.Redis;
-using ECommerceApp.Infrastructure.Interfaces;
+namespace ECommerceApp.Infrastructure.Services;
+
+using System.Text.Json;
 using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+using ECommerceApp.Infrastructure.Configurations;
+using ECommerceApp.Infrastructure.Interfaces;
 
-namespace ECommerceApp.Infrastructure.Services
+/// <summary>
+/// Redis-based implementation of ICacheService.
+/// </summary>
+public class RedisCacheService : ICacheService
 {
-    public class RedisCacheService: ICacheService
+    private readonly ConnectionMultiplexer _connectionMultiplexer;
+
+    public RedisCacheService(IOptions<RedisSettings> options)
     {
-        private readonly ConnectionMultiplexer _connectionMultiplexer;
-        
-        public RedisCacheService(IOptions<RedisSettings> options)
-        {
-            _connectionMultiplexer = ConnectionMultiplexer.Connect(options.Value.ConnectionString);
-        }
+        _connectionMultiplexer = ConnectionMultiplexer.Connect(options.Value.ConnectionString);
+    }
 
-        public IDatabase GetDb(int db = 0) => _connectionMultiplexer.GetDatabase(db);
+    /// <summary>
+    /// Gets the Redis database instance.
+    /// </summary>
+    public IDatabase GetDb(int db = 0) => _connectionMultiplexer.GetDatabase(db);
 
+    /// <summary>
+    /// Stores the given value in Redis under the specified key.
+    /// </summary>
+    public async Task SetAsync<T>(string key, T value)
+    {
+        var json = JsonSerializer.Serialize(value);
+        await GetDb().StringSetAsync(key, json);
+    }
+
+    /// <summary>
+    /// Retrieves a value from Redis based on the specified key.
+    /// </summary>
+    public async Task<T?> GetAsync<T>(string key)
+    {
+        var json = await GetDb().StringGetAsync(key);
+        return json.HasValue
+            ? JsonSerializer.Deserialize<T>(json!)
+            : default;
+    }
+
+    /// <summary>
+    /// Removes a cached value from Redis using the specified key.
+    /// </summary>
+    public async Task RemoveAsync(string key)
+    {
+        await GetDb().KeyDeleteAsync(key);
     }
 }

--- a/ECommerceApp.Tests/ApplicationTest/ProductServiceTests.cs
+++ b/ECommerceApp.Tests/ApplicationTest/ProductServiceTests.cs
@@ -1,0 +1,59 @@
+namespace ECommerceApp.Tests.ApplicationTest;
+
+using ECommerceApp.Application.DTOs.Product;
+using ECommerceApp.Application.Services;
+using ECommerceApp.Domain.Entities;
+using ECommerceApp.Domain.Repositories;
+using ECommerceApp.Infrastructure.Interfaces;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+
+[TestFixture]
+public class ProductServiceTests
+{
+    private Mock<IProductRepository> _mockRepository = null!;
+    private Mock<ICacheService> _mockCacheService = null!;
+    private Mock<ILogService> _mockLogService = null!;
+    private ProductService _productService = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockRepository = new Mock<IProductRepository>();
+        _mockCacheService = new Mock<ICacheService>();
+        _mockLogService = new Mock<ILogService>();
+
+        _productService = new ProductService(
+            _mockRepository.Object,
+            _mockCacheService.Object,
+            _mockLogService.Object
+        );
+    }
+
+    [Test]
+    public async Task GetAllAsync_Should_Return_Products_From_Cache_If_Present()
+    {
+        // Arrange
+        var cachedProducts = new List<ProductDto>
+        {
+            new ProductDto { Id = Guid.NewGuid(), Name = "Test Product", Price = 10, Currency = "USD", Stock = 100, Category = "Books" }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetAsync<List<ProductDto>>("products:all"))
+            .ReturnsAsync(cachedProducts);
+
+        // Act
+        var result = await _productService.GetAllAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(cachedProducts);
+
+        _mockRepository.Verify(r => r.GetAllAsync(), Times.Never);
+        _mockCacheService.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<List<ProductDto>>()), Times.Never);
+        _mockLogService.Verify(l => l.Info(It.IsAny<string>()), Times.AtLeastOnce);
+    }
+}

--- a/ECommerceApp.Tests/ECommerceApp.Tests.csproj
+++ b/ECommerceApp.Tests/ECommerceApp.Tests.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="FluentAssertions" Version="8.5.0" />
@@ -19,6 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\ECommerceApp.Application\ECommerceApp.Application.csproj" />
         <ProjectReference Include="..\ECommerceApp.Infrastructure\ECommerceApp.Infrastructure.csproj" />
     </ItemGroup>
 

--- a/ECommerceApp.Tests/IntegrationTests/Infrastructure/BalanceApiClientTest.cs
+++ b/ECommerceApp.Tests/IntegrationTests/Infrastructure/BalanceApiClientTest.cs
@@ -1,3 +1,5 @@
+namespace ECommerceApp.Tests.IntegrationTests.Infrastructure;
+
 using System.Text.Json;
 using ECommerceApp.Domain.DTOs.External;
 using ECommerceApp.Infrastructure.Configurations;
@@ -5,18 +7,20 @@ using ECommerceApp.Infrastructure.Interfaces;
 using ECommerceApp.Infrastructure.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
+using Moq;
 using NUnit.Framework;
-
-namespace ECommerceApp.Tests.IntegrationTests.Infrastructure;
 
 [TestFixture]
 public class BalanceApiClientTests
 {
     private IBalanceApiClient _balanceApiClient = null!;
+    private Mock<ILogService> _mockLogService = null!;
 
     [SetUp]
     public void SetUp()
     {
+        _mockLogService = new Mock<ILogService>();
+        
         var configuration = new ConfigurationBuilder()
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json")
@@ -29,7 +33,7 @@ public class BalanceApiClientTests
             BaseAddress = new Uri(balanceApiSettings.BalanceApiBaseUrl)
         };
 
-        _balanceApiClient = new BalanceApiClient(httpClient);
+        _balanceApiClient = new BalanceApiClient(httpClient, _mockLogService.Object);
     }
 
     [Test]


### PR DESCRIPTION
This PR introduces caching logic to the ProductService.GetAllAsync method. The service now first attempts to fetch product data from Redis cache. If the data is not available or Redis access fails, it falls back to the database and repopulates the cache.
