### PR TITLE
Add standardized ServiceResult and ServiceError wrapper for service layer responses

### DIFF
--- a/ECommerceApp.Api/Controllers/ProductsController.cs
+++ b/ECommerceApp.Api/Controllers/ProductsController.cs
@@ -28,7 +28,21 @@ public class ProductsController : ControllerBase
     [HttpGet]
     public async Task<IActionResult> GetAll()
     {
-        var products = await _productService.GetAllAsync();
-        return Ok(new { success = true, data = products });
+        var result = await _productService.GetAllAsync();
+
+        if (result.Succeeded)
+        {
+            return Ok(new { success = true, data = result.Data });
+        }
+
+        return BadRequest(new
+        {
+            success = false,
+            error = new
+            {
+                code = result.Error?.Code,
+                message = result.Error?.Message
+            }
+        });
     }
 }

--- a/ECommerceApp.Application/Common/ServiceError.cs
+++ b/ECommerceApp.Application/Common/ServiceError.cs
@@ -1,0 +1,26 @@
+namespace ECommerceApp.Application.Common;
+
+/// <summary>
+/// Represents an error occurred during a service operation.
+/// </summary>
+public class ServiceError
+{
+    /// <summary>
+    /// A machine-readable error code.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// A human-readable error message.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// ServiceError.
+    /// </summary>
+    public ServiceError(string code, string message)
+    {
+        Code = code;
+        Message = message;
+    }
+}

--- a/ECommerceApp.Application/Common/ServiceErrorCodes.cs
+++ b/ECommerceApp.Application/Common/ServiceErrorCodes.cs
@@ -1,0 +1,15 @@
+namespace ECommerceApp.Application.Common;
+
+/// <summary>
+/// Common error codes used by the application.
+/// </summary>
+public static class ServiceErrorCodes
+{
+    public const string NotFound = "NOT_FOUND";
+    public const string ValidationError = "VALIDATION_ERROR";
+    public const string Unauthorized = "UNAUTHORIZED";
+    public const string CacheError = "CACHE_ERROR";
+    public const string DatabaseError = "DATABASE_ERROR";
+    public const string ExternalServiceError = "EXTERNAL_SERVICE_ERROR";
+    public const string UnknownError = "UNKNOWN_ERROR";
+}

--- a/ECommerceApp.Application/Common/ServiceResult.cs
+++ b/ECommerceApp.Application/Common/ServiceResult.cs
@@ -1,0 +1,46 @@
+namespace ECommerceApp.Application.Common;
+
+/// <summary>
+/// Represents the outcome of a service operation.
+/// </summary>
+public class ServiceResult<T>
+{
+    /// <summary>
+    /// Indicates whether the operation was successful.
+    /// </summary>
+    public bool Succeeded { get; }
+
+    /// <summary>
+    /// The returned data (if successful).
+    /// </summary>
+    public T? Data { get; }
+
+    /// <summary>
+    /// The error details (if failed).
+    /// </summary>
+    public ServiceError? Error { get; }
+
+    private ServiceResult(bool succeeded, T? data = default, ServiceError? error = null)
+    {
+        Succeeded = succeeded;
+        Data = data;
+        Error = error;
+    }
+
+    /// <summary>
+    /// Creates a success result.
+    /// </summary>
+    public static ServiceResult<T> Success(T data) => new(true, data);
+
+    /// <summary>
+    /// Creates a failure result.
+    /// </summary>
+    public static ServiceResult<T> Failure(string code, string message) =>
+        new(false, default, new ServiceError(code, message));
+
+    /// <summary>
+    /// Creates a failure result from an error object.
+    /// </summary>
+    public static ServiceResult<T> Failure(ServiceError error) =>
+        new(false, default, error);
+}

--- a/ECommerceApp.Application/Interfaces/IProductService.cs
+++ b/ECommerceApp.Application/Interfaces/IProductService.cs
@@ -1,3 +1,4 @@
+using ECommerceApp.Application.Common;
 using ECommerceApp.Application.DTOs.Product;
 using ECommerceApp.Domain.Entities;
 
@@ -11,7 +12,7 @@ public interface IProductService
     /// <summary>
     /// Retrieves all products.
     /// </summary>
-    Task<IEnumerable<ProductDto>> GetAllAsync();
+    Task<ServiceResult<IEnumerable<ProductDto>>> GetAllAsync();
 
     /// <summary>
     /// Retrieves a product by its unique identifier.

--- a/ECommerceApp.Tests/ApplicationTest/ProductServiceTests.cs
+++ b/ECommerceApp.Tests/ApplicationTest/ProductServiceTests.cs
@@ -38,7 +38,15 @@ public class ProductServiceTests
         // Arrange
         var cachedProducts = new List<ProductDto>
         {
-            new ProductDto { Id = Guid.NewGuid(), Name = "Test Product", Price = 10, Currency = "USD", Stock = 100, Category = "Books" }
+            new ProductDto
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Product",
+                Price = 10,
+                Currency = "USD",
+                Stock = 100,
+                Category = "Books"
+            }
         };
 
         _mockCacheService
@@ -50,7 +58,9 @@ public class ProductServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(cachedProducts);
+        result.Succeeded.Should().BeTrue();
+        result.Data.Should().BeEquivalentTo(cachedProducts);
+        result.Error.Should().BeNull();
 
         _mockRepository.Verify(r => r.GetAllAsync(), Times.Never);
         _mockCacheService.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<List<ProductDto>>()), Times.Never);


### PR DESCRIPTION
This commit introduces a generic ServiceResult<T> wrapper to unify service layer responses across the application. The wrapper provides consistent success/error handling by encapsulating data, success status, and structured error information via a separate ServiceError class.
